### PR TITLE
ensure order export isnt trying to authenticate a spree user

### DIFF
--- a/app/controllers/concerns/solidus_wms/additional_orders_actions.rb
+++ b/app/controllers/concerns/solidus_wms/additional_orders_actions.rb
@@ -5,6 +5,7 @@ module SolidusWms
     extend ActiveSupport::Concern
 
     included do
+      skip_before_action :check_authorization
       before_filter :authenticate_basic_auth, only: [:export_xlsx]
     end
 


### PR DESCRIPTION
We've had a weird thing suddenly where the Jenkins job to hit this url and export the order is being automatically redirected to a login page (without sending the export), so we want to try adding this to see if it resolves the issue.